### PR TITLE
pomelo should upgrade 1.2.0, install error with 0.8.0

### DIFF
--- a/game-server/package.json
+++ b/game-server/package.json
@@ -3,7 +3,7 @@
 	"version": "0.0.1",
 	"private": false,
 	"dependencies": {
-		"pomelo": "0.8.0",
+		"pomelo": "1.2.0",
 		"crc": "0.2.0"
 	}
 }


### PR DESCRIPTION
when install with pomelo 0.8.0, I met error like this: 
> toobusy@0.2.2 install /Users/cphilo/programming/chatofpomelo-websocket/game-server/node_modules/pomelo/node_modules/toobusy
> node-gyp rebuild

blabla.....


make: *** [Release/obj.target/toobusy/toobusy.o] Error 1
gyp ERR! build error 
gyp ERR! stack Error: `make` failed with exit code: 2
gyp ERR! stack     at ChildProcess.onExit (/usr/local/lib/node_modules/npm/node_modules/node-gyp/lib/build.js:270:23)
gyp ERR! stack     at emitTwo (events.js:87:13)
gyp ERR! stack     at ChildProcess.emit (events.js:172:7)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:200:12)
gyp ERR! System Darwin 15.0.0
gyp ERR! command "/usr/local/Cellar/node/0.12.7/bin/node" "/usr/local/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
gyp ERR! cwd /Users/cphilo/programming/chatofpomelo-websocket/game-server/node_modules/pomelo/node_modules/toobusy
gyp ERR! node -v v4.2.1
gyp ERR! node-gyp -v v3.0.3
gyp ERR! not ok
